### PR TITLE
URLの取得のミス

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -49,7 +49,7 @@
         if (!body) {
             return;
         }
-        const url = match[1].replace(/^\[(.*):embed/, "$1");
+        const url = match[1].replace(/^\[?(.*):embed/, "$1");
         const owner = match[2];
         const repo = match[3];
         const ref = match[4];

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,7 +48,7 @@
     if(!body) {
       return;
     }
-    const url = match[1].replace(/^\[(.*):embed/, "$1");
+    const url = match[1].replace(/^\[?(.*):embed/, "$1");
     const owner = match[2];
     const repo = match[3];
     const ref = match[4];


### PR DESCRIPTION
aタグリンクの場合冒頭のブラケットが省略される可能性がある